### PR TITLE
Fix progress bar behavior and menu cleanup

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -60,6 +60,9 @@ const pauseBtn        = document.getElementById("pauseBtn");
 const skipBtn         = document.getElementById("skipBtn");
 const quitBtn         = document.getElementById("quitBtn");
 
+// container for pause/skip/quit
+const workoutControls = document.getElementById("workoutControls");
+
 const display         = document.getElementById("display");
 const exName          = document.getElementById("exerciseName");
 const timerEl         = document.getElementById("timer");
@@ -117,12 +120,32 @@ function buildProgressBar(rounds) {
 function updateProgress(roundIdx, pctIntoRound) {
   const segs = progressBar.children;
   [...segs].forEach((seg, i) => {
-    if (i < roundIdx) seg.className = "progress-seg progress-complete";
-    else if (i === roundIdx) seg.className = "progress-seg progress-active";
-    else seg.className = "progress-seg";
+    if (i < roundIdx) {
+      seg.className = "progress-seg progress-complete";
+      seg.style.background = "";
+    } else if (i === roundIdx) {
+      seg.className = "progress-seg progress-active";
+    } else {
+      seg.className = "progress-seg";
+      seg.style.background = "";
+    }
   });
   // fill current seg via inline gradient
   segs[roundIdx].style.background = `linear-gradient(to right,#4CAF50 ${pctIntoRound}%,#ddd ${pctIntoRound}%)`;
+}
+
+function updateRoundProgress() {
+  const current = seq[currentPhase];
+  const curRound = current.round;
+  let roundTotal = 0, roundElapsed = 0;
+  seq.forEach((p, idx) => {
+    if (p.round === curRound) {
+      roundTotal += p.duration;
+      if (idx < currentPhase) roundElapsed += p.duration;
+    }
+  });
+  const pct = (roundElapsed / roundTotal) * 100;
+  updateProgress(curRound - 1, pct);
 }
 
 // ---------- queue rendering ----------
@@ -167,6 +190,13 @@ function startWorkout() {
   buildSeq(w);
   buildProgressBar(w.rounds);
 
+  progressBar.classList.remove("hidden");
+  workoutControls.classList.remove("hidden");
+  pauseBtn.classList.remove("hidden");
+  skipBtn.classList.remove("hidden");
+  quitBtn.classList.remove("hidden");
+  queueEl.classList.remove("hidden");
+
   // flip screens
   menuScreen.classList.add("hidden");
   workoutScreen.classList.remove("hidden");
@@ -182,7 +212,10 @@ function nextPhase(){
   timeLeft = phase.duration;
   exName.textContent = phase.name;
   roundInfo.textContent = `Round ${phase.round} of ${workouts[select.value].rounds}`;
-  updateTimer(timeLeft);   renderQueue();   beep();
+  updateTimer(timeLeft);
+  renderQueue();
+  updateRoundProgress();
+  beep();
   clearInterval(intervalId);
   intervalId = setInterval(tick,1000);
 }
@@ -212,8 +245,17 @@ function tick() {
 
 function finishWorkout(){
   clearInterval(intervalId);
+  // ensure last round shows as complete
+  const totalRounds = workouts[select.value].rounds;
+  updateProgress(totalRounds - 1, 100);
+
   exName.textContent="Done!"; timerEl.textContent=""; roundInfo.textContent="";
-  pauseBtn.classList.add("hidden"); skipBtn.classList.add("hidden");
+  pauseBtn.classList.add("hidden");
+  skipBtn.classList.add("hidden");
+  quitBtn.classList.add("hidden");
+  workoutControls.classList.add("hidden");
+  progressBar.classList.add("hidden");
+
   startBtn.disabled=false; queueEl.classList.add("hidden"); beep();
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -45,14 +45,19 @@ select, button { width: 100%; padding: 10px; font-size: 1rem; margin-top: 6px; }
   display:flex;
   margin-bottom:18px;
   background:#ddd;
+  gap:2px;
 }
 .progress-seg {
   flex:1;
   background:#ddd;
   transition:background 0.2s linear;
+  height:8px;
 }
-.progress-active { background:#4CAF50; }   /* current round */
-.progress-complete { background:#8BC34A; } /* rounds done */
+.progress-active {
+  background:#4CAF50;
+  height:12px;
+}
+.progress-complete { background:#8BC34A; }
 
 /* ---- queue ---- */
 #queue { list-style:none; padding:0; margin:14px 0 0 0; font-size:0.85rem; }


### PR DESCRIPTION
## Summary
- ensure controls container is referenced
- fill out round progress immediately and clean up on finish
- hide progress bar & controls outside active workouts
- tweak progress bar styles to show gaps and thicker active bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e840d32108325829823cc7d916048