### PR TITLE
Add custom workout builder

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -71,6 +71,13 @@ const queueEl         = document.getElementById("queue");
 
 const preview         = document.getElementById("preview");
 const previewList     = document.getElementById("previewList");
+// custom form elements
+const customForm      = document.getElementById("customForm");
+const cwName          = document.getElementById("cwName");
+const cwExercises     = document.getElementById("cwExercises");
+const cwWork          = document.getElementById("cwWork");
+const cwRest          = document.getElementById("cwRest");
+const cwRounds        = document.getElementById("cwRounds");
 const menuScreen      = document.getElementById("menuScreen");
 const workoutScreen   = document.getElementById("workoutScreen");
 const progressBar     = document.getElementById("progressBar");
@@ -89,6 +96,35 @@ function goToMenu() {
   workoutControls.classList.add("hidden");
   progressBar.classList.add("hidden");
   menuBtn.classList.add("hidden");
+}
+
+// ---------- custom workout helpers ----------
+function saveCustomWorkout(w) {
+  const saved = JSON.parse(localStorage.getItem("customWorkouts") || "[]");
+  saved.push(w);
+  localStorage.setItem("customWorkouts", JSON.stringify(saved));
+}
+
+function loadCustomWorkouts() {
+  const saved = localStorage.getItem("customWorkouts");
+  if (!saved) return;
+  try {
+    const arr = JSON.parse(saved);
+    arr.forEach(w => workouts.push(w));
+  } catch (e) {}
+}
+
+function populateDropdown() {
+  select.innerHTML = "";
+  workouts.forEach((w, i) => {
+    const opt = document.createElement("option");
+    opt.value = i;
+    opt.textContent = w.name;
+    select.appendChild(opt);
+  });
+  select.selectedIndex = -1;
+  startBtn.disabled = true;
+  preview.classList.add("hidden");
 }
 
 // ---------- state ----------
@@ -314,11 +350,25 @@ confirmYes.onclick = () => {
   goToMenu();
 };
 
-// ---------- initial dropdown ----------
-workouts.forEach((w,i)=>{
-  const opt=document.createElement("option");
-  opt.value=i; opt.textContent=w.name;
-  select.appendChild(opt);
+// ---------- custom form handling ----------
+customForm.addEventListener("submit", e => {
+  e.preventDefault();
+  const workout = {
+    name: cwName.value.trim(),
+    rounds: parseInt(cwRounds.value, 10),
+    work: parseInt(cwWork.value, 10),
+    rest: parseInt(cwRest.value, 10),
+    exercises: cwExercises.value.split(",").map(s => s.trim()).filter(Boolean)
+  };
+  if (!workout.name || workout.exercises.length === 0) return;
+  workouts.push(workout);
+  saveCustomWorkout(workout);
+  populateDropdown();
+  select.value = workouts.length - 1;
+  renderPreview(workout);
+  customForm.reset();
 });
 
-select.selectedIndex = -1;
+// ---------- initial dropdown ----------
+loadCustomWorkouts();
+populateDropdown();

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,17 @@
       </div>
 
       <button id="startBtn" disabled>Start Workout</button>
+
+      <!-- -------- CUSTOM WORKOUT FORM -------- -->
+      <h3>Add Custom Workout</h3>
+      <form id="customForm">
+        <input id="cwName" type="text" placeholder="Name" required>
+        <input id="cwExercises" type="text" placeholder="Exercises (comma separated)" required>
+        <input id="cwWork" type="number" placeholder="Work (s)" required>
+        <input id="cwRest" type="number" placeholder="Rest (s)" required>
+        <input id="cwRounds" type="number" placeholder="Rounds" required>
+        <button type="submit">Save Workout</button>
+      </form>
     </div>
 
     <!-- ---------- WORKOUT SCREEN ---------- -->

--- a/docs/style.css
+++ b/docs/style.css
@@ -10,7 +10,7 @@ body {
 }
 #app { text-align: center; max-width: 340px; padding: 0 10px; }
 h1 { margin-bottom: 12px; font-size: 1.4rem; }
-select, button { width: 100%; padding: 10px; font-size: 1rem; margin-top: 6px; }
+select, button, input { width: 100%; padding: 10px; font-size: 1rem; margin-top: 6px; }
 #display { margin-top: 20px; }
 #exerciseName { font-size: 1.3rem; margin: 10px 0; }
 #timer { font-size: 3rem; margin: 10px 0; }


### PR DESCRIPTION
## Summary
- allow inputting custom workouts in `index.html`
- style text inputs consistently
- implement custom workout form handling in `app.js`
- save workouts to `localStorage` and load them on page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e8a7b6e10832581f0a5643a0ad18c